### PR TITLE
fix: fixed order of injecting css

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,6 @@
-import ThemeRegistry from '@global/theme/theme-registry'
-import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import { ReactNode } from 'react'
-
-const inter = Inter({ subsets: ['latin'] })
+import { ThemeRegistry } from '@global/theme'
+import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Resto-office',
@@ -11,10 +8,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
-      <ThemeRegistry options={{ key: 'mui' }}>
-        <body className={inter.className}>{children}</body>
-      </ThemeRegistry>
+    <html lang="ru">
+      <body>
+        <ThemeRegistry>{children}</ThemeRegistry>
+      </body>
     </html>
   )
 }

--- a/src/global/theme/emotion-cache.tsx
+++ b/src/global/theme/emotion-cache.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import createCache from '@emotion/cache'
+import { useServerInsertedHTML } from 'next/navigation'
+import { CacheProvider as DefaultCacheProvider } from '@emotion/react'
+import type {
+  EmotionCache,
+  Options as OptionsOfCreateCache,
+} from '@emotion/cache'
+import { ReactNode, useState } from 'react'
+
+export type EmotionCacheProviderProps = {
+  /** This is the options passed to createCache() from 'import createCache from "@emotion/cache"' */
+  options: Omit<OptionsOfCreateCache, 'insertionPoint'>
+  /** By default <CacheProvider /> from 'import { CacheProvider } from "@emotion/react"' */
+  CacheProvider?: (props: {
+    value: EmotionCache
+    children: ReactNode
+  }) => JSX.Element | null
+  children: ReactNode
+}
+
+// Adapted from https://github.com/garronej/tss-react/blob/main/src/next/appDir.tsx
+export default function EmotionCacheProvider(props: EmotionCacheProviderProps) {
+  const { options, CacheProvider = DefaultCacheProvider, children } = props
+
+  const [registry] = useState(() => {
+    const cache = createCache(options)
+    cache.compat = true
+    const prevInsert = cache.insert
+    let inserted: { name: string; isGlobal: boolean }[] = []
+    cache.insert = (...args) => {
+      const [selector, serialized] = args
+      if (cache.inserted[serialized.name] === undefined) {
+        inserted.push({
+          name: serialized.name,
+          isGlobal: !selector,
+        })
+      }
+      return prevInsert(...args)
+    }
+    const flush = () => {
+      const prevInserted = inserted
+      inserted = []
+      return prevInserted
+    }
+    return { cache, flush }
+  })
+
+  useServerInsertedHTML(() => {
+    const inserted = registry.flush()
+    if (inserted.length === 0) {
+      return null
+    }
+    let styles = ''
+    let dataEmotionAttribute = registry.cache.key
+
+    const globals: {
+      name: string
+      style: string
+    }[] = []
+
+    inserted.forEach(({ name, isGlobal }) => {
+      const style = registry.cache.inserted[name]
+
+      if (typeof style !== 'boolean') {
+        if (isGlobal) {
+          globals.push({ name, style })
+        } else {
+          styles += style
+          dataEmotionAttribute += ` ${name}`
+        }
+      }
+    })
+
+    return (
+      <>
+        {globals.map(({ name, style }) => (
+          <style
+            key={name}
+            data-emotion={`${registry.cache.key}-global ${name}`}
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html: options.prepend ? `@layer emotion {${style}}` : style,
+            }}
+          />
+        ))}
+        {styles && (
+          <style
+            data-emotion={dataEmotionAttribute}
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html: options.prepend ? `@layer emotion {${styles}}` : styles,
+            }}
+          />
+        )}
+      </>
+    )
+  })
+
+  return <CacheProvider value={registry.cache}>{children}</CacheProvider>
+}

--- a/src/global/theme/index.ts
+++ b/src/global/theme/index.ts
@@ -1,0 +1,1 @@
+export * from './theme-registry'

--- a/src/global/theme/theme.ts
+++ b/src/global/theme/theme.ts
@@ -2,11 +2,14 @@ import { Rubik } from 'next/font/google'
 import { createTheme, Theme } from '@mui/material/styles'
 
 const rubik = Rubik({
-  weight: ['300', '400'],
+  weight: ['300', '400', '500', '600', '700'],
   style: ['normal', 'italic'],
-  subsets: ['latin'],
+  subsets: ['latin', 'cyrillic-ext'],
 })
 
-export const muiTheme: Theme = createTheme({
+export const theme: Theme = createTheme({
+  palette: {
+    mode: 'light',
+  },
   typography: { fontFamily: rubik.style.fontFamily },
 })


### PR DESCRIPTION
Added ability for styling material components be custom css

Info about problem: https://mui.com/material-ui/guides/next-js-app-router/#css-injection-order

Implementation from: https://github.com/mui/material-ui/tree/master/examples/material-ui-nextjs-ts